### PR TITLE
Light/Dark Backgound Support + Time Updating

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/oz/tz
 go 1.15
 
 require (
-	github.com/charmbracelet/bubbletea v0.12.4
-	github.com/muesli/termenv v0.7.4
+	github.com/charmbracelet/bubbletea v0.13.1
+	github.com/muesli/termenv v0.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,11 @@
-github.com/charmbracelet/bubbletea v0.12.4 h1:2cfryCnDOe7SvQF/Dj99irXKpFlfoPgQjEDdvP1pLpk=
-github.com/charmbracelet/bubbletea v0.12.4/go.mod h1:tp9tr9Dadh0PLhgiwchE5zZJXm5543JYjHG9oY+5qSg=
+github.com/charmbracelet/bubbletea v0.13.1 h1:huvX8mPaeMZ8DLulT50iEWRF+iitY5FNEDqDVLu69nM=
+github.com/charmbracelet/bubbletea v0.13.1/go.mod h1:tp9tr9Dadh0PLhgiwchE5zZJXm5543JYjHG9oY+5qSg=
 github.com/containerd/console v1.0.1 h1:u7SFAJyRqWcG6ogaMAx3KjSTy1e3hT9QxqX7Jco7dRc=
 github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
 github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f/go.mod h1:nOFQdrUlIlx6M6ODdSpBj1NVA+VgLC6kmw60mkw34H4=
-github.com/lucasb-eyer/go-colorful v1.0.3 h1:QIbQXiugsb+q10B+MI+7DI1oQLdmnep86tWFlaaUAac=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
+github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
@@ -12,10 +13,9 @@ github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRR
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68 h1:y1p/ycavWjGT9FnmSjdbWUlLGvcxrY0Rw3ATltrxOhk=
 github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68/go.mod h1:Xk+z4oIWdQqJzsxyjgl3P22oYZnHdZ8FFTHAQQt5BMQ=
-github.com/muesli/termenv v0.7.2 h1:r1raklL3uKE7rOvWgSenmEm2px+dnc33OTisZ8YR1fw=
 github.com/muesli/termenv v0.7.2/go.mod h1:ct2L5N2lmix82RaY3bMWwVu/jUFc9Ule0KGDCiKYPh8=
-github.com/muesli/termenv v0.7.4 h1:/pBqvU5CpkY53tU0vVn+xgs2ZTX63aH5nY+SSps5Xa8=
-github.com/muesli/termenv v0.7.4/go.mod h1:pZ7qY9l3F7e5xsAOS0zCew2tME+p7bWeBkotCEcIIcc=
+github.com/muesli/termenv v0.8.0 h1:HxhDOZbpf9nSUhOiMUNk5jsL3XaKWAbHucoGYZf+nag=
+github.com/muesli/termenv v0.8.0/go.mod h1:kzt/D/4a88RoheZmwfqorY3A+tnsSMA9HJC/fQSFKo0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/main.go
+++ b/main.go
@@ -25,7 +25,10 @@ import (
 	"github.com/muesli/termenv"
 )
 
-var term = termenv.ColorProfile()
+var (
+	term              = termenv.ColorProfile()
+	hasDarkBackground = termenv.HasDarkBackground()
+)
 
 type model struct {
 	zones     []*Zone

--- a/view.go
+++ b/view.go
@@ -28,7 +28,7 @@ import (
 const UIWidth = 94
 
 func (m model) View() string {
-	s := "What time is it?\n\n"
+	s := normalTextStyle("\n  What time is it?\n\n").String()
 
 	// Show hours for each zone
 	for zi, zone := range m.zones {
@@ -48,7 +48,12 @@ func (m model) View() string {
 			out = out.Foreground(term.Color(hourColorCode(hour)))
 			// Cursor
 			if m.hour == i-startHour {
-				out = out.Background(term.Color("41")).Foreground(term.Color("#000000"))
+				out = out.Background(term.Color("#00B67F"))
+				if hasDarkBackground {
+					out = out.Foreground(term.Color("#262626")).Bold()
+				} else {
+					out = out.Foreground(term.Color("#f1f1f1"))
+				}
 			}
 			hours.WriteString(out.String())
 			hours.WriteString("  ")
@@ -66,10 +71,9 @@ func (m model) View() string {
 			}
 		}
 
-		zoneHeader := termenv.String(fmt.Sprintf("%s %s: %s", zone.ClockEmoji(), zone, zone.ShortDT()))
-		zoneHeader = zoneHeader.Background(term.Color("234")).Foreground(term.Color("255"))
+		zoneHeader := fmt.Sprintf("%s %s %s", zone.ClockEmoji(), normalTextStyle(zone.String()), dateTimeStyle(zone.ShortDT()))
 
-		s += fmt.Sprintf("%s\n%s\n%s\n\n", zoneHeader, hours.String(), dates.String())
+		s += fmt.Sprintf("  %s\n  %s\n  %s\n", zoneHeader, hours.String(), dates.String())
 	}
 
 	s += status()
@@ -77,7 +81,7 @@ func (m model) View() string {
 }
 
 func status() string {
-	text := "q: quit, d: toggle date"
+	text := "  q: quit, d: toggle date"
 	for {
 		text += " "
 		if len(text) > UIWidth {
@@ -85,7 +89,13 @@ func status() string {
 			break
 		}
 	}
-	status := termenv.String(text).Background(term.Color("234")).Foreground(term.Color("255"))
+
+	color := "#A1A093"
+	if hasDarkBackground {
+		color = "#605C5A"
+	}
+
+	status := termenv.String(text).Foreground(term.Color(color))
 
 	return status.String()
 }
@@ -95,9 +105,14 @@ func formatDayChange(m *model, z *Zone) string {
 	if zTime.Hour() > time.Now().Hour() {
 		zTime = zTime.AddDate(0, 0, 1)
 	}
-	str := termenv.String(fmt.Sprintf("📆%s", zTime.Format("Mon 02")))
-	str = str.Foreground(term.Color("245"))
-	return str.String()
+
+	color := "#777266"
+	if hasDarkBackground {
+		color = "#7B7573"
+	}
+
+	str := termenv.String(fmt.Sprintf("📆 %s", zTime.Format("Mon 02")))
+	return str.Foreground(term.Color(color)).String()
 }
 
 // Return a color matching the time of the day at a given hour.
@@ -105,19 +120,51 @@ func hourColorCode(hour int) (color string) {
 	switch hour {
 	// Morning
 	case 7, 8:
-		color = "12"
+		if hasDarkBackground {
+			color = "#98E1D8"
+		} else {
+			color = "#35B6A6"
+		}
 
 	// Day
 	case 9, 10, 11, 12, 13, 14, 15, 16, 17:
-		color = "227"
+		if hasDarkBackground {
+			color = "#E8C64D"
+		} else {
+			color = "#FA8F2D"
+		}
 
 	// Evening
 	case 18, 19:
-		color = "202"
+		if hasDarkBackground {
+			color = "#C95F48"
+		} else {
+			color = "#F9532F"
+		}
 
 	// Night
 	default:
-		color = "27"
+		if hasDarkBackground {
+			color = "#5957C9"
+		} else {
+			color = "#664FC3"
+		}
 	}
 	return color
+}
+
+func dateTimeStyle(str string) termenv.Style {
+	color := "#777266"
+	if hasDarkBackground {
+		color = "#757575"
+	}
+	return termenv.String(str).Foreground(term.Color(color))
+}
+
+func normalTextStyle(str string) termenv.Style {
+	var color = "#32312B"
+	if hasDarkBackground {
+		color = "#ECEAD9"
+	}
+	return termenv.String(str).Foreground(term.Color(color))
 }

--- a/view.go
+++ b/view.go
@@ -89,7 +89,7 @@ func status() string {
 		}
 	}
 
-	color := "#A1A093"
+	color := "#939183"
 	if hasDarkBackground {
 		color = "#605C5A"
 	}
@@ -138,7 +138,7 @@ func hourColorCode(hour int) (color string) {
 		if hasDarkBackground {
 			color = "#C95F48"
 		} else {
-			color = "#F9532F"
+			color = "#FC6442"
 		}
 
 	// Night

--- a/view.go
+++ b/view.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/muesli/termenv"
 )
@@ -102,7 +101,7 @@ func status() string {
 
 func formatDayChange(m *model, z *Zone) string {
 	zTime := z.currentTime()
-	if zTime.Hour() > time.Now().Hour() {
+	if zTime.Hour() > m.now.Hour() {
 		zTime = zTime.AddDate(0, 0, 1)
 	}
 


### PR DESCRIPTION
Hi! This is _mostly_ a style-based PR aimed at increasing readability for this already wonderful tool.

* Color adjustments with light and dark variants, chosen automatically based on the terminal's background color
* Small formatting adjustments
* The time now updates every minute with the system clock
* Bubble Tea and Termenv are bumped to their latest versions

I tried to follow the spirit of the screenshot in the README when choosing colors, but I know this is an opinionated pull request. Feel free to push further edits to my branch, take certain parts and drop the rest, or reject the PR entirely.

I thoroughly enjoyed reading your code, by the way, and learned a few things from it.

<img width="755" alt="dark" src="https://user-images.githubusercontent.com/25087/111093283-e56b8f80-850e-11eb-82db-b43d4bcee5c7.png">

<img width="750" alt="light" src="https://user-images.githubusercontent.com/25087/111093289-e7cde980-850e-11eb-950e-782882bf5046.png">
