### PR TITLE
Introducing two new config parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ environment variable to override it.
 
 `TZ_LOCAL_NAME="Cologe office`
 
+## Display time format
+
+In the header line, tz will display the current time. By default the time format
+for the time is in 12H format. If you prefer to display the time in 24H format, 
+you can do so by setting `TZ_24H`
+
+`TZ_24H=1`
+
 # Building
 
 You need a recent-ish release of go with modules support:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ tz name followed by `;` and your alias:
 
 `TZ_LIST="Europe/Paris;EMEA office,US/Central;US office"`
 
+## Name of local zone
+
+tz, by default, displays your local timezone as "Local". If you rather like
+to display a different name there instead, you can use the `TZ_LOCAL_NAME`
+environment variable to override it.
+
+`TZ_LOCAL_NAME="Cologe office`
 
 # Building
 

--- a/config.go
+++ b/config.go
@@ -44,11 +44,19 @@ func LoadConfig() (*Config, error) {
 	}
 	zones := make([]*Zone, len(tzConfigs)+1)
 
+	// "Local" can be overwritten by TZ_LOCAL_NAME
+	var localIdentifier string
+	if localName := os.Getenv("TZ_LOCAL_NAME"); localName == "" {
+		localIdentifier = "Local"
+	} else {
+		localIdentifier = localName
+	}
+
 	// Setup with Local time zone
 	now := time.Now()
 	localZoneName, offset := now.Zone()
 	zones[0] = &Zone{
-		Name:   fmt.Sprintf("(%s) Local", localZoneName),
+		Name:   fmt.Sprintf("(%s) %s", localZoneName, localIdentifier),
 		DbName: localZoneName,
 		Offset: offset / 3600,
 	}

--- a/config.go
+++ b/config.go
@@ -25,13 +25,20 @@ import (
 
 // Config stores app configuration
 type Config struct {
-	Zones []*Zone
+	Zones   []*Zone
+	TimeFmt int
 }
 
 // LoadConfig from environment
 func LoadConfig() (*Config, error) {
 	conf := Config{
-		Zones: DefaultZones,
+		Zones:   DefaultZones,
+		TimeFmt: 12,
+	}
+
+	// Allow 24h time format
+	if tzTimeFmt := os.Getenv("TZ_24H"); tzTimeFmt != "" {
+		conf.TimeFmt = 24
 	}
 
 	tzList := os.Getenv("TZ_LIST")

--- a/config.go
+++ b/config.go
@@ -41,16 +41,6 @@ func LoadConfig() (*Config, error) {
 		conf.TimeFmt = 24
 	}
 
-	tzList := os.Getenv("TZ_LIST")
-	if tzList == "" {
-		return &conf, nil
-	}
-	tzConfigs := strings.Split(tzList, ",")
-	if len(tzConfigs) == 0 {
-		return &conf, nil
-	}
-	zones := make([]*Zone, len(tzConfigs)+1)
-
 	// "Local" can be overwritten by TZ_LOCAL_NAME
 	var localIdentifier string
 	if localName := os.Getenv("TZ_LOCAL_NAME"); localName == "" {
@@ -58,6 +48,17 @@ func LoadConfig() (*Config, error) {
 	} else {
 		localIdentifier = localName
 	}
+
+	tzList := os.Getenv("TZ_LIST")
+	if tzList == "" {
+		conf.Zones[0].Name = localIdentifier
+		return &conf, nil
+	}
+	tzConfigs := strings.Split(tzList, ",")
+	if len(tzConfigs) == 0 {
+		return &conf, nil
+	}
+	zones := make([]*Zone, len(tzConfigs)+1)
 
 	// Setup with Local time zone
 	now := time.Now()

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ type model struct {
 	now       time.Time
 	hour      int
 	showDates bool
+	timeFmt   int
 }
 
 func (m model) Init() tea.Cmd {
@@ -96,6 +97,7 @@ func main() {
 		now:       now,
 		hour:      now.Hour(),
 		showDates: false,
+		timeFmt:   config.TimeFmt,
 	}
 	p := tea.NewProgram(initialModel)
 	if err := p.Start(); err != nil {

--- a/view.go
+++ b/view.go
@@ -70,7 +70,7 @@ func (m model) View() string {
 			}
 		}
 
-		zoneHeader := fmt.Sprintf("%s %s %s", zone.ClockEmoji(), normalTextStyle(zone.String()), dateTimeStyle(zone.ShortDT()))
+		zoneHeader := fmt.Sprintf("%s %s %s", zone.ClockEmoji(), normalTextStyle(zone.String()), dateTimeStyle(zone.ShortDT(m.timeFmt)))
 
 		s += fmt.Sprintf("  %s\n  %s\n  %s\n", zoneHeader, hours.String(), dates.String())
 	}

--- a/zone.go
+++ b/zone.go
@@ -66,8 +66,12 @@ func (z Zone) ClockEmoji() (clock string) {
 }
 
 // ShortDT returns the current time in short format.
-func (z Zone) ShortDT() string {
-	return z.currentTime().Format("3:04PM, Mon 02")
+func (z Zone) ShortDT(f int) string {
+	if f == 24 {
+		return z.currentTime().Format("15:04, Mon 02")
+	} else {
+		return z.currentTime().Format("3:04PM, Mon 02")
+	}
 }
 
 func (z Zone) currentTime() time.Time {


### PR DESCRIPTION
- TZ_LOCAL_NAME: allows to override the display of "Local" with a name of coice
- TZ_24H: allows to display the header time in 24h format instead of 12h format