### PR TITLE
Trim the zone config to support spaces in TZ_LIST.

### DIFF
--- a/config.go
+++ b/config.go
@@ -69,7 +69,7 @@ func LoadConfig() (*Config, error) {
 // SetupZone from current time and a zoneConf string
 func SetupZone(now time.Time, zoneConf string) (*Zone, error) {
 	names := strings.Split(zoneConf, ";")
-	dbName := names[0]
+	dbName := strings.Trim(names[0], " ")
 	var name string
 	if len(names) == 2 {
 		name = names[1]

--- a/config_test.go
+++ b/config_test.go
@@ -36,6 +36,11 @@ func TestSetupZone(t *testing.T) {
 			zoneName: "America/London",
 			ok:       false,
 		},
+		{
+			// Names should be trimmed in the config, so this should be ok.
+			zoneName: " Australia/Sydney",
+			ok: 	  true,
+		},
 	}
 	for _, test := range tests {
 		_, err := SetupZone(now, test.zoneName)


### PR DESCRIPTION
This trims the string before looking it up in SetupZone - which
ensures obscure messages like: "Config error: looking up zone
Europe/Dublin: unknown time zone Europe/Dublin" (notice the double
space before Europe/Dublin) are avoided, when a user configures
TZ_LIST with spaces after the ','.

Added a testcase to config_test for this as well.