### PR TITLE
allow "-when" on the command line

### DIFF
--- a/config.go
+++ b/config.go
@@ -45,7 +45,7 @@ func LoadConfig() (*Config, error) {
 	zones := make([]*Zone, len(tzConfigs)+1)
 
 	// Setup with Local time zone
-	now := time.Now()
+	now := clock()
 	localZoneName, offset := now.Zone()
 	zones[0] = &Zone{
 		Name:   fmt.Sprintf("(%s) Local", localZoneName),

--- a/main.go
+++ b/main.go
@@ -91,8 +91,21 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+var clock func() time.Time = time.Now
+
 func main() {
-	now := time.Now()
+	exitQuick := flag.Bool("q", false, "exit immediately")
+	when := flag.Int64("when", 0, "time in seconds since unix epoch")
+	flag.Parse()
+
+	if *when != 0 {
+		t := time.Unix(*when, 0)
+		clock = func() time.Time {
+			return t
+		}
+	}
+
+	now := clock()
 	config, err := LoadConfig()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Config error: %s\n", err)
@@ -105,8 +118,6 @@ func main() {
 		showDates: false,
 	}
 
-	exitQuick := flag.Bool("q", false, "exit immediately")
-	flag.Parse()
 	initialModel.interactive = !*exitQuick
 
 	p := tea.NewProgram(initialModel)

--- a/zone.go
+++ b/zone.go
@@ -71,7 +71,7 @@ func (z Zone) ShortDT() string {
 }
 
 func (z Zone) currentTime() time.Time {
-	now := time.Now()
+	now := clock()
 	zName, _ := now.Zone()
 	if z.DbName != zName {
 		loc, err := time.LoadLocation(z.DbName)


### PR DESCRIPTION
Implements #8 but takes the timestamp as a unix timestamp.  `go run ./... -when $( gdate -d '+3 month' +%s )`