### PR TITLE
Fix "Zone Alias" README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ tz is configured only through `TZ_LIST`, and that limits us to the tz
 database names, but you can alias these names using a special value: the
 tz name followed by `;` and your alias:
 
-`TZ_LIST="Europe/Paris,EMEA office;US/Central,US office"`
+`TZ_LIST="Europe/Paris;EMEA office,US/Central;US office"`
 
 # Building
 


### PR DESCRIPTION
**Problem:** Example doesn't match TZ_LIST configuration description. 

**Changes made:** Replaced `;` with `,` and vice versa. 