### PR TITLE
Fix #4: Support timezones with non-hourly (non-integer) UTC offsets

### DIFF
--- a/config.go
+++ b/config.go
@@ -48,11 +48,10 @@ func LoadConfig(tzConfigs []string) (*Config, error) {
 
 	// Setup with Local time zone
 	now := Now.Time()
-	localZoneName, offset := now.Zone()
+	localZoneName, _ := now.Zone()
 	zones[0] = &Zone{
 		Name:   fmt.Sprintf("(%s) Local", localZoneName),
 		DbName: localZoneName,
-		Offset: offset / 3600,
 	}
 
 	// Add zones from TZ_LIST
@@ -85,10 +84,9 @@ func SetupZone(now time.Time, zoneConf string) (*Zone, error) {
 		name = loc.String()
 	}
 	then := now.In(loc)
-	shortName, offset := then.Zone()
+	shortName, _ := then.Zone()
 	return &Zone{
 		DbName: loc.String(),
 		Name:   fmt.Sprintf("(%s) %s", shortName, name),
-		Offset: offset / 3600,
 	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ import (
 )
 
 // CurrentVersion represents the current build version.
-const CurrentVersion = "0.6.2"
+const CurrentVersion = "0.6.3"
 
 var (
 	term              = termenv.ColorProfile()

--- a/view.go
+++ b/view.go
@@ -36,7 +36,7 @@ func (m model) View() string {
 
 		startHour := 0
 		if zi > 0 {
-			startHour = (zone.Offset - m.zones[0].Offset) % 24
+			startHour = (zone.currentTime().Hour() - m.zones[0].currentTime().Hour()) % 24
 		}
 
 		dateChanged := false

--- a/zone.go
+++ b/zone.go
@@ -18,17 +18,15 @@ package main
 
 import "time"
 
-var name, offset = time.Now().Zone()
+var name, _ = time.Now().Zone()
 var DefaultZones = []*Zone{
 	{
 		Name:   "Local",
 		DbName: name,
-		Offset: offset / 3600,
 	},
 	{
 		Name:   "UTC",
 		DbName: "UTC",
-		Offset: 0,
 	},
 }
 
@@ -48,11 +46,10 @@ var EmojiClocks = map[int]string{
 	11: "🕙",
 }
 
-// Zone stores the name of a time zone and its integer offset from UTC.
+// Zone stores the name of a time zone
 type Zone struct {
 	DbName string // Name in tzdata
 	Name   string // Short name
-	Offset int    // Integer offset from UTC, in hours.
 }
 
 func (z Zone) String() string {


### PR DESCRIPTION
Use the correct start hour for all timezones even when the UTC offset isn’t a round number of hours.

Before this fix the wrong start hour (integer) was calculated when timezones involved a part-hour offset, causing the wrong current hour to be highlighted, and entire timezone rows to be misaligned. This bug #4 impacted `tz` for more than a billion people. For example when working with India Standard Time (IST = UTC+05:30, known as “Asia/Calcutta” in `tkuchiki/go-timezone`) at UTC=12:45, `tz` could align India with 5 am as the current displayed hour but it should have been 6 am.

This fix uses the same approach as the emojis, which were displayed correctly.