### PR TITLE
feat: add military time

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ type model struct {
 	hour        int
 	showDates   bool
 	interactive bool
+	isMilitary  bool
 }
 
 func (m model) Init() tea.Cmd {
@@ -105,6 +106,7 @@ func main() {
 	showVersion := flag.Bool("v", false, "show version")
 	when := flag.Int64("when", 0, "time in seconds since unix epoch")
 	doSearch := flag.Bool("list", false, "list zones by name")
+	military := flag.Bool("m", false, "use 24-hour time")
 	flag.Parse()
 
 	if *showVersion == true {
@@ -131,10 +133,11 @@ func main() {
 		os.Exit(2)
 	}
 	var initialModel = model{
-		zones:     config.Zones,
-		now:       Now.Time(),
-		hour:      Now.Time().Hour(),
-		showDates: false,
+		zones:      config.Zones,
+		now:        Now.Time(),
+		hour:       Now.Time().Hour(),
+		showDates:  false,
+		isMilitary: *military,
 	}
 
 	initialModel.interactive = !*exitQuick

--- a/main_test.go
+++ b/main_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -120,4 +121,18 @@ func TestUpdateQuitMsg(t *testing.T) {
 	}
 	// tea.Quit is a function, we can't really test with == here, and
 	// calling it is getting into internal territory.
+}
+
+func TestMilitaryTime(t *testing.T) {
+	m := model{
+		zones:      DefaultZones,
+		hour:       14,
+		now:        Now.Time(),
+		isMilitary: true,
+		showDates:  true,
+	}
+	s := m.View()
+	if !strings.Contains(s, m.now.Format("15:04")) {
+		t.Errorf("Expected military time of %s, but got %s", m.now.Format("15:04"), s)
+	}
 }

--- a/view.go
+++ b/view.go
@@ -70,7 +70,14 @@ func (m model) View() string {
 			}
 		}
 
-		zoneHeader := fmt.Sprintf("%s %s %s", zone.ClockEmoji(), normalTextStyle(zone.String()), dateTimeStyle(zone.ShortDT()))
+		var datetime string
+		if m.isMilitary {
+			datetime = zone.ShortMT()
+		} else {
+			datetime = zone.ShortDT()
+		}
+
+		zoneHeader := fmt.Sprintf("%s %s %s", zone.ClockEmoji(), normalTextStyle(zone.String()), dateTimeStyle(datetime))
 
 		s += fmt.Sprintf("  %s\n  %s\n  %s\n", zoneHeader, hours.String(), dates.String())
 	}

--- a/zone.go
+++ b/zone.go
@@ -67,6 +67,11 @@ func (z Zone) ShortDT() string {
 	return z.currentTime().Format("3:04PM, Mon 02")
 }
 
+// ShortMT returns the current military time in short format.
+func (z Zone) ShortMT() string {
+	return z.currentTime().Format("15:04, Mon 02")
+}
+
 func (z Zone) currentTime() time.Time {
 	now := Now.Time()
 	zName, _ := now.Zone()


### PR DESCRIPTION
Adds the ability to display time in the military time format (24 hours), addressing #31 