### PR TITLE
Adds 12 hour AM/PM time view

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,15 @@
+---
+version: 3
+
+tasks:
+  run:
+    cmds:
+      - go run main.go
+  
+  build:
+    cmds:
+      - go build
+  
+  test:
+    cmds:
+      - go test

--- a/main.go
+++ b/main.go
@@ -48,12 +48,13 @@ func tick() tea.Cmd {
 }
 
 type model struct {
-	zones       []*Zone
-	now         time.Time
-	hour        int
-	showDates   bool
-	interactive bool
-	isMilitary  bool
+	zones        []*Zone
+	now          time.Time
+	hour         int
+	showDates    bool
+	interactive  bool
+	isMilitary   bool
+	isTwelveHour bool
 }
 
 func (m model) Init() tea.Cmd {
@@ -107,6 +108,7 @@ func main() {
 	when := flag.Int64("when", 0, "time in seconds since unix epoch")
 	doSearch := flag.Bool("list", false, "list zones by name")
 	military := flag.Bool("m", false, "use 24-hour time")
+	twelveHour := flag.Bool("t", false, "use 12-hour time")
 	flag.Parse()
 
 	if *showVersion == true {
@@ -133,11 +135,12 @@ func main() {
 		os.Exit(2)
 	}
 	var initialModel = model{
-		zones:      config.Zones,
-		now:        Now.Time(),
-		hour:       Now.Time().Hour(),
-		showDates:  false,
-		isMilitary: *military,
+		zones:        config.Zones,
+		now:          Now.Time(),
+		hour:         Now.Time().Hour(),
+		showDates:    false,
+		isMilitary:   *military,
+		isTwelveHour: *twelveHour,
 	}
 
 	initialModel.interactive = !*exitQuick

--- a/view.go
+++ b/view.go
@@ -50,7 +50,7 @@ func (m model) View() string {
 				if hour == 0 {
 					hour = 12
 				}
-				if i >= 12 {
+				if i%24 >= 12 {
 					period = "PM"
 				} else {
 					period = "  "
@@ -80,9 +80,16 @@ func (m model) View() string {
 			if hour == 0 {
 				dates.WriteString(formatDayChange(&m, zone))
 				dateChanged = true
+			} else if hour == 12 && period != "PM" {
+				dates.WriteString(formatDayChange(&m, zone))
+				dateChanged = true
 			}
-			if !dateChanged {
+
+			// handle the spacing for the date/calendar icon
+			if !dateChanged && !m.isTwelveHour {
 				dates.WriteString("    ")
+			} else if m.isTwelveHour && !dateChanged {
+				dates.WriteString("      ")
 			}
 		}
 

--- a/view.go
+++ b/view.go
@@ -41,8 +41,24 @@ func (m model) View() string {
 
 		dateChanged := false
 		for i := startHour; i < startHour+24; i++ {
-			hour := ((i % 24) + 24) % 24 // mod 24
-			out := termenv.String(fmt.Sprintf("%2d", hour))
+			var hour int
+			var period string
+
+			// switch AM/PM vs 24-hour in future view
+			if m.isTwelveHour {
+				hour = ((i % 24) + 24) % 12
+				if hour == 0 {
+					hour = 12
+				}
+				if i >= 12 {
+					period = "PM"
+				} else {
+					period = "  "
+				}
+			} else {
+				hour = ((i % 24) + 24) % 24 // mod 24
+			}
+			out := termenv.String(fmt.Sprintf("%2d%s", hour, period))
 
 			out = out.Foreground(term.Color(hourColorCode(hour)))
 			// Cursor
@@ -70,6 +86,7 @@ func (m model) View() string {
 			}
 		}
 
+		// switch current timestamp from 12 to 24 hour
 		var datetime string
 		if m.isMilitary {
 			datetime = zone.ShortMT()


### PR DESCRIPTION
Adds flag (`-t`) to show AM/PM 12-hour view. Adjusted the spacing so the date shows in interactive mode. `-m` is unchanged.