### PR TITLE
Dynamic right-alignment of dates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,4 +21,5 @@ require (
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035 // indirect
 	golang.org/x/text v0.3.8 // indirect
+	golang.org/x/tools v0.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -65,4 +65,6 @@ golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
+golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/testdata/view/test-right-alignment.txt
+++ b/testdata/view/test-right-alignment.txt
@@ -1,0 +1,25 @@
+-- expected --
+  🕛 UTC 00:01, Sun Nov 05, 2017
+  🕛 UTC                                               00:01, Sun Nov 05, 2017
+  🕛 UTC                                                                   00:01, Sun Nov 05, 2017
+-- observed: narrow --
+
+  What time is it?
+
+  🕛 UTC 00:01, Sun Nov 05, 2017
+   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  
+  📆 Sun 05
+-- observed: medium --
+
+  What time is it?
+
+  🕛 UTC                                               00:01, Sun Nov 05, 2017
+   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  
+  📆 Sun 05
+-- observed: wide --
+
+  What time is it?
+
+  🕛 UTC                                                                   00:01, Sun Nov 05, 2017
+   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  
+  📆 Sun 05

--- a/view_test.go
+++ b/view_test.go
@@ -1,0 +1,83 @@
+/**
+ * This file is part of tz.
+ *
+ * tz is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * tz is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with tz.  If not, see <https://www.gnu.org/licenses/>.
+ **/
+package main
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/txtar"
+)
+
+func TestRightAlignment(t *testing.T) {
+	testDataFile := "testdata/view/test-right-alignment.txt"
+	testData, err := txtar.ParseFile(testDataFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := stripAnsiControlSequencesAndNewline(testData.Files[0].Data)
+
+	tests := []struct {
+		columns int
+	}{
+		{columns: 1},
+		{columns: 80},
+		{columns: 999},
+	}
+
+	originalColumns := os.Getenv("COLUMNS")
+	var observations []string
+	for _, test := range tests {
+		os.Setenv("COLUMNS", strconv.Itoa(test.columns))
+		observed := stripAnsiControlSequences(utcMinuteAfterMidnightModel.View())
+		observations = append(observations, observed)
+	}
+	os.Setenv("COLUMNS", originalColumns)
+
+	archive := txtar.Archive{
+		Comment: testData.Comment,
+		Files: []txtar.File{
+			{
+				Name: "expected",
+				Data: []byte(expected),
+			},
+			{
+				Name: "observed: narrow",
+				Data: []byte(observations[0]),
+			},
+			{
+				Name: "observed: medium",
+				Data: []byte(observations[1]),
+			},
+			{
+				Name: "observed: wide",
+				Data: []byte(observations[2]),
+			},
+		},
+	}
+	os.WriteFile(testDataFile, txtar.Format(&archive), 0666)
+
+	expectations := strings.Split(expected, "\n")
+	for i, test := range tests {
+		if !strings.Contains(observations[i], expectations[i]) {
+			t.Errorf("Expected %d-column alignment “%s”, but got: “%s”", test.columns, expectations[i], observations[i])
+		}
+	}
+}


### PR DESCRIPTION
- Use COLUMNS env var or dynamic terminal width (up to UIWidth max)
- Refresh each time, in case the user’s terminal is resized
- Fix #53 (regression since e4e6d44)

This PR also adds some unit test support:
- main.test.go: Stable UTC data model for reproducible tests
- main.test.go: stripAnsiControlSequences to ignore colours (clean test data)
- view_test.go: Use txtar to read, write, and annotate human-readable test data (easy git diffing)
- testdata/view: Test dynamic right-alignment of dates in narrow, medium, and wide cases