### PR TITLE
Clock repair and military-time testing

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -5,26 +5,37 @@ import "time"
 // Clock keeps track of the current time.
 type Clock struct {
 	t time.Time
+	isRealTime bool
 }
 
-// Make a new Clock.
-//
-// When "sec" is not t0, the returned Clock is set to this time,
-// assuming "sec" is a UNIX timestamp (cf. time.Unix).
-func NewClock(sec int64) *Clock {
+// A new Clock in the local timezone at the current time now.
+func NewClockNow() *Clock {
 	clock := new(Clock)
+	clock.t = time.Now()
+	clock.isRealTime = true
+	return clock
+}
 
-	if sec != 0 {
-		clock.t = time.Unix(sec, 0)
-	} else {
-		clock.t = time.Now()
-	}
+// A new Clock with the given time and timezone.
+func NewClockTime(t time.Time) *Clock {
+	clock := new(Clock)
+	clock.t = t
+	clock.isRealTime = false
+	return clock
+}
+
+// A new Clock in the local timezone at the `time.Unix` timestamp.
+func NewClockUnixTimestamp(sec int64) *Clock {
+	clock := new(Clock)
+	clock.t = time.Unix(sec, 0)
+	clock.isRealTime = false
 	return clock
 }
 
 // AddDays adds n days to the current date.
 func (c *Clock) AddDays(n int) {
 	c.t = c.t.AddDate(0, 0, n)
+	c.isRealTime = false
 }
 
 // AddDays adds n days to the current date and clears the minutes
@@ -40,6 +51,7 @@ func (c *Clock) AddHours(n int) {
 		c.t.Location(),
 	)
 	c.t = c.t.Add(time.Hour * time.Duration(n))
+	c.isRealTime = false
 }
 
 // Get the wrapped time.Time struct

--- a/clock_test.go
+++ b/clock_test.go
@@ -1,0 +1,61 @@
+/**
+ * This file is part of tz.
+ *
+ * tz is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * tz is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with tz.  If not, see <https://www.gnu.org/licenses/>.
+ **/
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewClockNow(t *testing.T) {
+	start := time.Now()
+	clock := NewClockNow()
+	if clock.t.Compare(start) < 0 {
+		t.Errorf("Unexpected old time from NewClockNow(): %v", clock.t.Format(time.RFC3339))
+	}
+	if !clock.isRealTime {
+		t.Error("NewClockNow() wasn’t real time")
+	}
+}
+
+func TestClockTime(t *testing.T) {
+	epoch, err := time.Parse(time.RFC3339, "1970-01-01T01:03:05Z")
+	if err != nil {
+		t.Fatalf("Could not parse test epoch")
+	}
+	clock := NewClockTime(epoch)
+	if clock.t.Compare(epoch) != 0 {
+		t.Errorf("Unexpected time from NewClockTime(epoch): %v", clock.t.Format(time.RFC3339))
+	}
+	if clock.isRealTime {
+		t.Error("NewClockTime() shouldn’t be real time")
+	}
+}
+
+func TestClockUnixTimestamp(t *testing.T) {
+	epoch, err := time.Parse(time.RFC3339, "1970-01-01T00:00:01Z")
+	if err != nil {
+		t.Fatalf("Could not parse test epoch")
+	}
+	clock := NewClockUnixTimestamp(1)
+	if clock.t.Compare(epoch) != 0 {
+		t.Errorf("Unexpected time from NewClockUnixTimestamp(1): %v", clock.t.Format(time.RFC3339))
+	}
+	if clock.isRealTime {
+		t.Error("NewClockUnixTimestamp() shouldn’t be real time")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			openInTimeAndDateDotCom(m.clock.Time())
 
 		case match(key, m.keymaps.Now):
-			m.clock = *NewClock(0)
+			m.clock = *NewClockNow()
 
 		case match(key, m.keymaps.ToggleDate):
 			m.showDates = !m.showDates
@@ -139,8 +139,8 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tickMsg:
-		if m.watch {
-			m.clock = *NewClock(0)
+		if m.watch && m.clock.isRealTime {
+			m.clock = *NewClockNow()
 		}
 		return m, tick()
 	}
@@ -153,7 +153,7 @@ func main() {
 
 	exitQuick := flag.Bool("q", false, "exit immediately")
 	showVersion := flag.Bool("v", false, "show version")
-	when := flag.Int64("when", 0, "time in seconds since unix epoch")
+	when := flag.Int64("when", 0, "time in seconds since unix epoch (disables -w)")
 	doSearch := flag.Bool("list", false, "list zones by name")
 	military := flag.Bool("m", false, "use 24-hour time")
 	watch := flag.Bool("w", false, "watch live, set time to now every minute")
@@ -183,7 +183,7 @@ func main() {
 	var initialModel = model{
 		zones:      config.Zones,
 		keymaps:    config.Keymaps,
-		clock:      *NewClock(0),
+		clock:      *NewClockNow(),
 		showDates:  false,
 		isMilitary: *military,
 		watch:      *watch,
@@ -191,7 +191,7 @@ func main() {
 	}
 
 	if *when != 0 {
-		initialModel.clock = *NewClock(*when)
+		initialModel.clock = *NewClockUnixTimestamp(*when)
 	}
 
 	initialModel.interactive = !*exitQuick && isatty.IsTerminal(os.Stdout.Fd())

--- a/main_test.go
+++ b/main_test.go
@@ -40,13 +40,13 @@ var (
 	)
 	utcMinuteAfterMidnightModel = model{
 		zones:      DefaultZones[len(DefaultZones) - 1:],
-		clock:      *NewClock(utcMinuteAfterMidnightTime.Unix()),
+		clock:      *NewClockTime(utcMinuteAfterMidnightTime),
 		isMilitary: true,
 		showDates:  true,
 	}
 )
 
-func getTimestampWithHour(hour int) int64 {
+func getTimestampWithHour(hour int) time.Time {
 	if hour == -1 {
 		hour = time.Now().Hour()
 	}
@@ -59,7 +59,7 @@ func getTimestampWithHour(hour int) int64 {
 		0, // Seconds set to 0
 		0, // Nanoseconds set to 0
 		time.Now().Location(),
-	).Unix()
+	)
 }
 
 func stripAnsiControlSequences(s string) string {
@@ -94,7 +94,7 @@ func TestUpdateIncHour(t *testing.T) {
 		m := model{
 			zones:   DefaultZones,
 			keymaps: NewDefaultConfig().Keymaps,
-			clock:   *NewClock(getTimestampWithHour(test.startHour)),
+			clock:   *NewClockTime(getTimestampWithHour(test.startHour)),
 		}
 
 		db := m.clock.Time().Day()
@@ -137,7 +137,7 @@ func TestUpdateDecHour(t *testing.T) {
 		m := model{
 			zones:   DefaultZones,
 			keymaps: NewDefaultConfig().Keymaps,
-			clock:   *NewClock(getTimestampWithHour(test.startHour)),
+			clock:   *NewClockTime(getTimestampWithHour(test.startHour)),
 		}
 		nextState, cmd := m.Update(msg)
 		if cmd != nil {
@@ -162,7 +162,7 @@ func TestUpdateQuitMsg(t *testing.T) {
 	m := model{
 		zones:   DefaultZones,
 		keymaps: NewDefaultConfig().Keymaps,
-		clock:   *NewClock(getTimestampWithHour(-1)),
+		clock:   *NewClock(),
 	}
 	_, cmd := m.Update(msg)
 	if cmd == nil {
@@ -176,7 +176,7 @@ func TestUpdateQuitMsg(t *testing.T) {
 func TestMilitaryTime(t *testing.T) {
 	m := model{
 		zones:      DefaultZones,
-		clock:      *NewClock(getTimestampWithHour(-1)),
+		clock:      *NewClock(),
 		isMilitary: true,
 		showDates:  true,
 	}

--- a/testdata/main/test-military-time.txt
+++ b/testdata/main/test-military-time.txt
@@ -1,0 +1,12 @@
+Military time is (a) 24-hour time (b) padded with leading zeros (c) without an AM/PM suffix.
+For example, one minute past midnight is “0001” (neither unpadded 24-hour “0:01” nor 12-hour suffixed “12:01AM”).
+However for clarity, we include a colon delimiter between hours and minutes anyway:
+-- expected --
+ 00:01, Sun Nov 05, 2017
+-- observed --
+
+  What time is it?
+
+  🕛 UTC                                                                   00:01, Sun Nov 05, 2017
+   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  
+  📆 Sun 05


### PR DESCRIPTION
This PR helps fix some timezone and testability bugs in unreleased HEAD since v0.7.0:

- Add unit test coverage for clock.go and fix TestMilitaryTime (help ea0c421 #56)
- Preserve timezone in model clock (fix 0bdd6e2 #57)
- Watch flag -w compatibility with keyboard navigation and -when (fix 057fc06 #58)

This PR depends on first resolving issue #53 by merging PR #54, as the latter contains fixes for the formatting, which impacts the unit test data/expectations in this PR.